### PR TITLE
Improve tabs padding

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -26,8 +26,12 @@ ol
 .el-tabs
 	&__content
 		background-color #f6f8fd
-		padding 1em
+		padding 2em
 		border-radius 8px
+	h3
+		margin-top 0em
+  ol:last-child
+	  margin-bottom 0em
 
 // Yuu theme changes
 .yuu-theme-dark


### PR DESCRIPTION
Add space into tabs to make the text less close from the borders.

Change `.el-tabs__content` padding from `1em`to `2em`.
Remove `margin-top` of `h3`and last `ol`component.

Potential issue:
The tabs need to have only one `h3` at the begging and the last element have to be an `ol`component.