### PR TITLE
Fix typo and tabs padding issue

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -64,7 +64,6 @@ ol
 	.el-tabs
 		&__content
 			background-color #252525
-			padding 1em
 			border-radius 8px
 			h3
 				color $accentColor

--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -30,7 +30,7 @@ If you're having problems with the application, please check here before posting
 ---
 
 ### App crashes when trying to follow on iPad
-This is a known Apple bug that is fixed in iPadOS 13.4, Update to iOS 13.4 or avoid following manga from Paperback and use MangaDex's website to follow (and then sync).
+This is a known Apple bug that is fixed in iPadOS 13.4, Update to iPadOS 13.4 or avoid following manga from Paperback and use MangaDex's website to follow (and then sync).
 
 ---
 
@@ -52,7 +52,7 @@ Also make sure that your email is verified.
 ---
 
 ### The reader is open but stays blank when I try to read a chapter
- * Switch between the horizontal/vertical viewers. If switching doesn't fix, try to read the same chapter on safari, if it works, ping @Paper on Discord in #support channel.
+ * Switch between the horizontal/vertical viewers. If switching doesn't fix, try to read the same chapter on Safari, if it works, ping @Paper on Discord in #support channel.
  * Some chapters are taken off of MangaDex due to group conflicts or chapters being scans of the official TL.
 
 ---


### PR DESCRIPTION
Fix padding issue in dark mode: remove `1em` padding from `.yuu-theme-dark .el-tabs__content` to make the component inherit from `2em` padding from `.el-tabs__content`.

Correct two typo.