### PR TITLE
Enlarge internal links in sidebar on mobile

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -155,6 +155,12 @@ ol
 		@media (max-width: $MQMobile)
 			display inherit
 
+.sidebar 
+  .nav-links
+	  .nav-link
+		  // Enlarge internal links in sidebar
+		  display: block
+
 // Page Header Logo
 .headerLogo
 	vertical-align middle

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -156,10 +156,10 @@ ol
 			display inherit
 
 .sidebar 
-  .nav-links
-	  .nav-link
-		  // Enlarge internal links in sidebar
-		  display: block
+	.nav-links
+		.nav-link
+			// Enlarge internal links in sidebar
+			display block
 
 // Page Header Logo
 .headerLogo


### PR DESCRIPTION
This pull request enlarge the touchable box of internal links in side bar.
It will make the navigation easier on mobile as it allow to touche the right of the text to open links. Moreover this comportment exist already in external links so it would make sense to add it for internal links.

Before this modification the `a` component inherited of `display: inline-block` from the theme.
It overwrite display property of `.sidebar .nav-links .nav-link` component with `display: block`.

I did not find any issues caused by this change, I hope there isn't.

---

Here is the touchable zone before the modification:
![before](https://user-images.githubusercontent.com/25133304/82139030-6097e280-9825-11ea-9d0e-8b40fc52984b.png)
And after:
![after](https://user-images.githubusercontent.com/25133304/82139034-62fa3c80-9825-11ea-98d3-1b82d3f86fd2.png)

