### PR TITLE
Repository source listings render as bulleted lists

### DIFF
--- a/src/.vuepress/components/ExtensionsList.vue
+++ b/src/.vuepress/components/ExtensionsList.vue
@@ -6,18 +6,14 @@ The url argument must be of the form "https://paperback-ios.github.io/extensions
 
 <template>
 	<div>
-		<span v-for="extension in extensions"
-		:id="extension.name"
-		:key="extension.id"
-		class="anchor"
-		>
-			<span v-if="extension.id == last_id.id">
-				{{extension.name}}
-			</span>
-			<span v-else>
-				{{extension.name}},
-			</span>
-		</span>
+		<ul id="v-for-object">
+			<li v-for="extension in extensions"
+			:id="extension.name"
+			:key="extension.id"
+			>
+				{{ extension.name }}
+			</li>
+		</ul>
 
 	</div>
 </template>

--- a/src/help/guides/adding-repos.md
+++ b/src/help/guides/adding-repos.md
@@ -25,7 +25,7 @@ Currently external sources are only available on the Beta version of the applica
 ## Known Repositories
 This is a list of all of the known repositories currently for Paperback, as well as the repository contents.
 | Repository Name | Base URL | Available Sources | Notes |
-| :-------------: | :------: | :---------------: | :---: |
+| :-------------: | :------: | :---------------- | :---: |
 | **Official Repository** | Built into Paperback | <ExtensionsList url="https://paperback-ios.github.io/extensions"/> | Officialy maintained repository, sources which are available and simply need enabled inside of the app
 | **H-Extensions**    | https://paperback-ios.github.io/h-extensions | <ExtensionsList url="https://paperback-ios.github.io/h-extensions"/> | Official repository for 18+ sources. These also include redirector versions of the source, which allow you to view content even if it is blocked in your country, without a VPN
 | **Beta Extensions** | https://conradweiser.github.io/extensions | <ExtensionsList url="https://conradweiser.github.io/extensions"/> | These extensions are upcoming to the official repository. These sources may or may not work. |


### PR DESCRIPTION
Instead of comma separating sources which sometimes looks like a bit of a mess, perhaps we should consider rendering it as bulleted lists!

![image](https://user-images.githubusercontent.com/9699789/86145779-5b38e380-bac5-11ea-923f-a8ec6b333f16.png)
