### PR TITLE
Update http-proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5075,8 +5075,7 @@
 		"eventemitter3": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-			"dev": true
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
 		},
 		"events": {
 			"version": "3.1.0",
@@ -6241,10 +6240,9 @@
 			}
 		},
 		"http-proxy": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
-			"dev": true,
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
 			"requires": {
 				"eventemitter3": "^4.0.0",
 				"follow-redirects": "^1.0.0",
@@ -9737,8 +9735,7 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resize-observer-polyfill": {
 			"version": "1.5.1",


### PR DESCRIPTION
Update http-proxy from version `1.18.0` to `1.18.1`.

This should fix two high vulnerabilities:
 * https://npmjs.com/advisories/1486
 * https://npmjs.com/advisories/1486

As suggested by `npm audit` I used the command:
```bash
npm update http-proxy --depth 5
```