### PR TITLE
Update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7191,10 +7191,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",


### PR DESCRIPTION
Update lodash from version `4.17.15` to `4.17.19`.

This should resolve 333 low vulnerabilities including the Dependabot alert one.

As suggested by `npm audit` I used the command:
```bash
npm update lodash --depth 12
```