### PR TITLE
Deactivate service worker

### DIFF
--- a/src/.vuepress/config/plugins.js
+++ b/src/.vuepress/config/plugins.js
@@ -7,8 +7,7 @@ module.exports = [
 	[
 		"@vuepress/pwa",
 		{
-			serviceWorker: true,
-			updatePopup: true,
+			serviceWorker: false,
 		},
 	],
 	/* Containers */


### PR DESCRIPTION
As suggested by Soitora, this pull request set `serviceWorker` to `false` in plugins.js. 
This should deactivate service worker generation and registration.