### PR TITLE
Update getting-started for TestFlight public build

### DIFF
--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -15,8 +15,8 @@ There are no decent manga apps on **iOS** and **iPadOS** that have _non-intrusiv
 There are no plans to adopt a formal business model. As long as Patreon covers the costs of an Apple Developer Account, profit is secondary. It would be nice to get support for development of the app, but there will be no fee to use Paperback.
 
 ### Where can I find this app?
-Currently an early version of the app is available on the App Store! [Click here](https://apps.apple.com/app/paperback-manga-reader/id1519509781) to download a copy.
-If you are a patreon, you will recieve an email to your patreon address regarding information about accessing Paperback through TestFlight. The TestFlight version of the application contains many additional beta features which can be used before it becomes available on the App Store.
+Currently an early version of the app is available on TestFlight! Check [Paperback Installation Guide](/help/guides/getting-started) to download a copy.
+If you are a patreon, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The TestFlight version of the application contains many additional beta features which can be used before it becomes available on the public one.
 
 **NOTE** 
 * (August 1st): The app is currently not available in the US, UK, Canada, Japan, South Korea, New Zealand, India and South Africa. We're working on getting the app back into the Appstore in those countries, but if you want to get the app you can make a new Apple ID from a country outside of the blocked countries.

--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -16,6 +16,7 @@ There are no plans to adopt a formal business model. As long as Patreon covers t
 
 ### Where can I find this app?
 Currently an early version of the app is available on TestFlight! Check [Paperback Installation Guide](/help/guides/getting-started) to download a copy.
+
 If you are a patreon, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The TestFlight version of the application contains many additional beta features which can be used before it becomes available on the public one.
 
 **NOTE** 

--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -7,6 +7,7 @@ lang: en-US
 
 ## Installation
 Currently an early version of the app is available on TestFlight!
+
 If you are a patron, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The Patreon version of the application contains many additional beta features which can be used before it becomes available on the public one.
 
 ::: warning Warning

--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -6,8 +6,8 @@ lang: en-US
 # Getting started
 
 ## Installation
-Currently an early version of the app is available on the App Store! [Click here](https://apps.apple.com/app/paperback-manga-reader/id1519509781) to download a copy.
-If you are a patron, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The TestFlight version of the application contains many additional beta features which can be used before it becomes available on the App Store.
+Currently an early version of the app is available on TestFlight!
+If you are a patron, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The Patreon version of the application contains many additional beta features which can be used before it becomes available on the public one.
 
 ::: warning Warning
 This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the app will CRASH. Paperback is NOT designed for older iOS versions.
@@ -15,10 +15,13 @@ This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the a
 
 :::: el-tabs
 ::: el-tab-pane label="Public version"
-### App Store
+### TestFlight
 #### Instructions
-1. Installing the public version of Paperback is easy! Simply navigate to the [App Store](https://apps.apple.com/app/paperback-manga-reader/id1519509781) and download a copy!
-
+1. Remove every other version of Paperback
+1. Download the [TestFlight app](https://apps.apple.com/fr/app/testflight/id899247664) from App Store
+1. Accept the invite by going here https://testflight.apple.com/join/hLKHUuEr or redeem the code `hLKHUuEr`
+1. Download the application through TestFlight
+   > Whenever there is an update to the application, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
 :::
 
 ::: el-tab-pane label="Patreon version"

--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -19,7 +19,7 @@ This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the a
 #### Instructions
 1. Remove every other version of Paperback
 1. Download the [TestFlight app](https://apps.apple.com/fr/app/testflight/id899247664) from App Store
-1. Accept the invite by going here https://testflight.apple.com/join/hLKHUuEr or redeem the code `hLKHUuEr`
+1. Accept the invite by going here [https://testflight.apple.com/join/hLKHUuEr](https://testflight.apple.com/join/hLKHUuEr) or redeem the code `hLKHUuEr`
 1. Download the application through TestFlight
    > Whenever there is an update to the application, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
 :::


### PR DESCRIPTION
This pull request update Paperback installation guide and faq for the new public TestFlight build. 

The following note is not really useful anymore, should we delete it?
```
**NOTE** 
* (August 1st): The app is currently not available in the US, UK, Canada, Japan, South Korea, New Zealand, India and South Africa. We're working on getting the app back into the Appstore in those countries, but if you want to get the app you can make a new Apple ID from a country outside of the blocked countries.
```