### PR TITLE
Add Genkan and Madara repos

### DIFF
--- a/src/help/guides/adding-repos.md
+++ b/src/help/guides/adding-repos.md
@@ -62,7 +62,7 @@ Following repositories will only work on the most recent beta (version 2.X.X).
         description="ONLY WORKS IN BETA 2.X.X Contains sources using the Madara templa
 te" />
     <ExtensionsList
-        url="https://gamefuzzy.github.io/extensions-genkan"
+        url="https://dev.gamefuzzy.me/extensions-genkan"
         name="[PROMISES] Genkan Extensions"
         description="ONLY WORKS IN BETA 2.X.X Contains scanlation sources using the Genkan template" />
 </div>

--- a/src/help/guides/adding-repos.md
+++ b/src/help/guides/adding-repos.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # External Source Repositories
 ## What is an External Repository?
-**Paperback** out of the box only comes with **SafeDex** as a source for manga. The app however has support for adding sources from external repositories which are not on the official listings. Beta Sources, 18+ Sources, and sources developed independently are separated due to **Paperback** having to adhere to Apple policies in order to be distributed through TestFlight and the Apple App Store. 
+**Paperback** out of the box only comes with **SafeDex** as a source for manga. The app however has support for adding sources from external repositories which are not on the official listings. Beta Sources, 18+ Sources, and sources developed independently are separated due to **Paperback** having to adhere to Apple policies in order to be distributed through TestFlight and the Apple App Store.
 
 ## Adding an External Repository
 1. Visit [Known Repositories](/help/guides/adding-repos/#known-repositories) on your Device's web browser.
@@ -28,7 +28,7 @@ Following repositories will only work on Paperback version prior to 2.X.X. Use t
         url="https://paperback-ios.github.io/extensions-beta"
         name="Primary Sources"
         description="Officially maintained repository, contains a few major sources suited for most users" />
-    <ExtensionsList 
+    <ExtensionsList
         url="https://paperback-ios.github.io/h-extensions"
         name="H-Extensions"
         description="Official repository for 18+ sources. These also include redirector versions of the source, which allow you to view content even if it is blocked in your country, without a VPN" />
@@ -36,7 +36,7 @@ Following repositories will only work on Paperback version prior to 2.X.X. Use t
         url="https://paperback-ios.github.io/extensions-foreign"
         name="Foreign Extensions"
         description="Contains official sources for languages other than English" />
-    <ExtensionsList 
+    <ExtensionsList
         url="https://pogogo007.github.io/extensions-beta"
         name="MangaDex Unlocked"
         description="This source overwrites MangaDex and unlocks the full contents of the website. No content is filtered. May load faster" />
@@ -50,10 +50,19 @@ Following repositories will only work on the most recent beta (version 2.X.X).
 <div>
     <ExtensionsList
         url="https://paperback-ios.github.io/extensions-promises"
-        name="[Promises] Primary Sources"
+        name="[PROMISES] Primary Sources"
         description="ONLY WORKS IN BETA 2.X.X Some additional sources for the app" />
     <ExtensionsList
         url="https://paperback-ios.github.io/h-extensions/promises"
         name="[PROMISES] H-Extensions"
         description="ONLY WORKS IN BETA 2.X.X Official repository for 18+ sources" />
+    <ExtensionsList
+        url="https://paperback-ios.github.io/extensions-madara"
+        name="[PROMISES] Madara Extensions"
+        description="ONLY WORKS IN BETA 2.X.X Contains sources using the Madara templa
+te" />
+    <ExtensionsList
+        url="https://gamefuzzy.github.io/extensions-genkan"
+        name="[PROMISES] Genkan Extensions"
+        description="ONLY WORKS IN BETA 2.X.X Contains scanlation sources using the Genkan template" />
 </div>

--- a/src/help/guides/adding-repos.md
+++ b/src/help/guides/adding-repos.md
@@ -59,8 +59,7 @@ Following repositories will only work on the most recent beta (version 2.X.X).
     <ExtensionsList
         url="https://paperback-ios.github.io/extensions-madara"
         name="[PROMISES] Madara Extensions"
-        description="ONLY WORKS IN BETA 2.X.X Contains sources using the Madara templa
-te" />
+        description="ONLY WORKS IN BETA 2.X.X Contains sources using the Madara template" />
     <ExtensionsList
         url="https://dev.gamefuzzy.me/extensions-genkan"
         name="[PROMISES] Genkan Extensions"


### PR DESCRIPTION
Added two repos and capitalized `PROMISES` in `name="[Promises] Primary Sources"` because it was bugging me. The trailing spaces being removed is something I'm pretty sure my IDE did on its own. Don't think it makes any difference.