### PR TITLE
Add a LinkedCode component

### DIFF
--- a/src/.vuepress/components/CodeLinked.vue
+++ b/src/.vuepress/components/CodeLinked.vue
@@ -1,0 +1,190 @@
+<!--
+Highlight and render in a code block the text passed as a <slot>.
+The component will link popovers to keywords defined in KeywordsData using CodePopover component.
+
+To keep spaces and indentation, the component can be used with 
+
+::: linkedcode js
+```
+CODE
+```
+:::
+
+<CodeLinked language="js">
+```
+CODE
+```
+</CodeLinked
+-->
+
+<template>
+<!--<div :class="'language-' + language">-->
+<pre :class="'linked-code language-' + language">
+<code><slot></slot></code>
+</pre>
+<!--</div>-->
+</template>
+
+<script>
+
+// Prism is used for syntax highlighting
+import Prism from 'prismjs'
+import 'prismjs/components/prism-typescript';
+
+// Additionals pluggins
+//import 'prismjs/plugins/show-language/prism-show-language.js'
+//import 'prismjs/plugins/keep-markup/prism-keep-markup.js'
+// class = "no-keep-markup "
+
+
+// https://github.com/PrismJS/prism/blob/80d475e4d8ddc8c5d744a4143b3078545d72d6aa/prism.js#L47
+
+// We don't want Prism to render all code blocks, including on other pages
+// We will manually call highlightElement for this vue component in `mounted`
+Prism.manual = true;
+
+// Vue is used to add the popover component
+import Vue from 'vue'
+import CodePopoverVue from './CodePopover.vue'
+
+// Define which words should be linked
+const KeywordsData = {
+    createRequestObject: {
+        title: "RequestObject",
+        link: "/help/guides/extension-development/model-reference/#request",
+        desc: "Make a request",
+        parameters: ["url: string", "method: string", "..."]
+    },
+    createChapter: {
+        title: "Chapter",
+        link: "/help/guides/extension-development/model-reference/#chapter",
+        desc: "Contains most metadata about a chapter.",
+        parameters: ["id: string", "mangaId: string", "chapNum: Number"]
+    },
+	createManga: {
+        title: "Manga",
+        link: "/help/guides/extension-development/model-reference/#manga",
+        desc: "Represent a Manga",
+        parameters: ["id: string", "titles: [string]"]
+    },
+}
+
+export default {
+    props: {
+		// Language of the code, used for syntax highlighting
+		language: {
+			type: String,
+			required: false,
+		},
+    },
+	async mounted() {
+		// We highlight this component 
+		const code = this.$el
+		Prism.highlightElement(code);
+
+		// Parameter: async: bool
+
+		// We can highlight only a particular component
+		//const code = this.$el.getElementsByClassName("linked-code")
+		//Prism.highlightElement(code.children[0]);
+		
+	}
+}
+
+// After the syntax highlighting, we search for registred keywords in KeywordsData and 
+// replace them with instances of CodePopover component
+Prism.hooks.add('after-highlight', function (env) {
+
+	//if (env.element.classList.contains('linked-code') && env.element.parentNode.tagName.toLowerCase() === 'pre') { // If <code> countains linked-code
+	if (env.element.classList.contains('linked-code') && env.element.tagName.toLowerCase() === 'pre') {
+			/*
+			console.log("after-highlight");
+			console.log(env)
+
+			console.log(`code: ${env.code}`)
+			console.log(`html: ${env.element.innerHTML}`)
+			*/
+            
+			// We find keywords and use a <span> placeholder to be able to find them with getElementsByClassName
+            for (const keyword of Object.keys(KeywordsData)) {
+                env.element.innerHTML = env.element.innerHTML.replaceAll(keyword, `<span class="replacePlaceholder">${keyword}</span>`)
+            }
+            
+            let itemsCollection = env.element.getElementsByClassName("replacePlaceholder")
+            
+			//console.log(itemsCollection)
+
+            // Adding CodePopover components must be done after all innerHTML modifications
+            // as modifying innerHTML indeed breaks associated events
+
+            // The following loop will destroy element from the HTMLCollection itemsCollection one by one and replace them by CodePopover instances
+            while (itemsCollection.length > 0) {
+                const item = itemsCollection[0]
+
+				// The parent is used to replace item
+				const itemParent = item.parentNode
+
+				// The keyword was previously passed as innerText
+                const keyword = item.innerText
+
+				/*
+                console.log("Length itemsCollection", itemsCollection.length)
+                console.log("item", item)
+                console.log("item innertext", item.innerText)
+                console.log("item parent",itemParent)
+				*/
+
+				// We create a new instance of CodePopover component, with data from KeywordsData[keyword]
+				// https://css-tricks.com/creating-vue-js-component-instances-programmatically/#creating-the-instance
+                var ComponentClass = Vue.extend(CodePopoverVue)
+                var instance = new ComponentClass({
+                    propsData: { code: keyword,
+                                 title: KeywordsData[keyword].title,
+                                 link: KeywordsData[keyword].link,
+                                 desc: KeywordsData[keyword].desc,
+                                 parameters: KeywordsData[keyword].parameters}
+                })
+				instance.$mount()
+                
+				// We replace item with our new CodePopover component
+                itemParent.replaceChild(instance.$el, item);
+            }
+	}
+})
+</script>
+
+<style lang="stylus">
+.el-popover__reference
+	cursor pointer
+
+pre.linked-code
+	// Code block style
+	font-size 0.85em
+	font-family source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace
+	padding-bottom 0px !important
+	// Language name
+	position relative
+	&::before
+		position absolute
+		z-index 3
+		top 0.8em
+		right 1em
+		font-size 0.75rem
+		color rgba(255, 255, 255, 0.4)
+
+// Language name
+// https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/theme-default/styles/code.styl
+for lang in js ts
+	pre.linked-code.language-{lang}
+		&:before
+			content ('' + lang)
+
+pre.language-javascript
+	&:before
+		content "js"
+
+pre.language-typescript
+	&:before
+		content "ts"
+
+</style>

--- a/src/.vuepress/components/CodePopover.vue
+++ b/src/.vuepress/components/CodePopover.vue
@@ -1,0 +1,81 @@
+<!--
+Create a popover element for CodeLinked
+-->
+
+<template>
+	<span>
+		<el-popover
+			placement="top"
+			trigger="click"
+    		> 
+			<!-- Alternative trigger: v-model="visible" or trigger="hover" --> <!--width="160"-->
+
+			<a :href="link"><code class="codepopover-title" > {{ title }} </code></a>
+			<p> 
+				<span> {{ desc }} </span>
+				<br/>
+				<span v-for="parameter in parameters" :key="parameter" class="codepopover-parameter"> {{ parameter }} <br/> </span>
+			</p>
+			<span slot="reference" @click="visible = true">{{ code }}</span>
+		</el-popover>
+	</span>
+</template>
+
+<script>
+
+export default {
+    data() {
+      return {
+        visible: false,
+      };
+    },
+	props: {
+		code: {
+			// Text that will be rendered as the reference of the popover
+			type: String,
+			required: true
+		},
+		title: {
+			// Title of the popover windows
+			type: String,
+			required: true,
+		},
+		link: {
+			// Link of the title of the popover
+			type: String,
+			required: true,
+		},
+		desc: {
+			// Description rendered in the popover
+			type: String,
+			required: true,
+		},
+		parameters: {
+			// List of parameters rendered in the popover
+			type: Array,
+			required: false,
+		},
+	},
+
+};
+
+</script>
+
+<style lang="stylus">
+:not(pre)
+	code.codepopover-title
+			color #476582
+			padding 0.25rem 0.5rem
+			margin 0
+			font-size 0.85em
+			background-color rgba(27,31,35,0.05)
+			border-radius 3px
+			cursor pointer
+	code.codepopover-title:hover
+		text-decoration underline
+	.codepopover-parameter
+		margin-left 10px
+		font-family source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace
+		font-size 0.85em
+	
+</style>

--- a/src/.vuepress/config/plugins.js
+++ b/src/.vuepress/config/plugins.js
@@ -25,6 +25,14 @@ module.exports = [
 	[
 		"vuepress-plugin-container",
 		{
+			type: "linkedcode",
+			before: (info) => `<CodeLinked language="${info}">`,
+			after: "</CodeLinked>",
+		},
+	],
+	[
+		"vuepress-plugin-container",
+		{
 			type: "aside",
 			defaultTitle: "",
 		},

--- a/src/help/guides/extension-development/codelinkedtest.md
+++ b/src/help/guides/extension-development/codelinkedtest.md
@@ -1,0 +1,81 @@
+# Available keywords:
+ * RequestObject
+ * Chapter
+ * Manga
+
+# Using `::: linkedcode ts`
+
+::: linkedcode ts
+```ts
+async getMangaDetails(mangaId: string): Promise<Manga> {
+
+    // Create a createRequestObject which when executed, will yield a HTML page containing the data needed to fill out a Manga object
+    const request = createRequestObject({
+        url: `https://yourwebsite.com/manga/${mangaId}`,
+        method: 'GET'
+    })
+
+    return createChapter({ ... })
+
+    // Prepare to parse the page using CheerioJS (Class object included by parent class)
+    let $ = this.cheerio.load(data.data)
+
+    // ALWAYS use the createManga({ }) wrapper when returning
+    return createManga({
+        id: mangaId,
+        titles: ...
+        // etc
+    })
+}
+```
+:::
+
+# Using `<CodeLinked language="ts">`
+<CodeLinked language="ts">
+```typescript
+async getMangaDetails(mangaId: string): Promise<Manga> {
+
+    // Create a createRequestObject which when executed, will yield a HTML page containing the data needed to fill out a Manga object
+    const request = createRequestObject({
+        url: `https://yourwebsite.com/manga/${mangaId}`,
+        method: 'GET'
+    })
+
+    return createChapter({ ... })
+
+    // Prepare to parse the page using CheerioJS (Class object included by parent class)
+    let $ = this.cheerio.load(data.data)
+
+    // ALWAYS use the createManga({ }) wrapper when returning
+    return createManga({
+        id: mangaId,
+        titles: ...
+        // etc
+    })
+}
+```
+</CodeLinked>
+
+# Classic code block
+```js
+async getMangaDetails(mangaId: string): Promise<Manga> {
+
+    // Create a createRequestObject which when executed, will yield a HTML page containing the data needed to fill out a Manga object
+    const request = createRequestObject({
+        url: `https://yourwebsite.com/manga/${mangaId}`,
+        method: 'GET'
+    })
+
+    return createChapter({ ... })
+
+    // Prepare to parse the page using CheerioJS (Class object included by parent class)
+    let $ = this.cheerio.load(data.data)
+
+    // ALWAYS use the createManga({ }) wrapper when returning
+    return createManga({
+        id: mangaId,
+        titles: ...
+        // etc
+    })
+}
+```


### PR DESCRIPTION
In order to make the documentation easier to use, especially code blocs, this pull request implement a way to show popovers for certain registered keywords.

### How does this work
Like classic code blocs that are currently used, this new component use [Prismjs](https://prismjs.com/) to highlight the component content.

After the component is mounted, it calls `Prism.highlightElement(code)` to run the highlight process.
An `after-highlight` hook is registred. It is run after the highlight process and replaces keywords by instances of `CodePopover`.

### How to use it in the documentation
For the moment keywords are registered in `KeywordsData` in `LinkedCode.vue` file component. We can change this depending how we want to use this component.

It can be used with:

    ::: linkedcode js
    ```
    CODE
    ```
    :::

or

    <CodeLinked language="js">
    ```
    CODE
    ```
    </CodeLinked>

---

This pull request intend to create a first version of the component. The main question, if this component should be used, will be: what should be shown in the popover dialog? For the moment all popover have a predefined code containing a title, a description and a parameters list. It could be possible to define other layouts. It would also be possible to define the html code of the popover for each keywords.