### PR TITLE
MangaDex to MangaDex backup migrator

### DIFF
--- a/src/.vuepress/components/MdToMdMigrator.vue
+++ b/src/.vuepress/components/MdToMdMigrator.vue
@@ -1,0 +1,515 @@
+<!--
+There are three steps:
+0	The user can upload a backup
+1	The user is shown information about the backup and can start the conversion
+2	Conversion process
+3	The new backup can be downloaded
+The variable activeStep indicate the current step
+-->
+
+<template>
+	<span>
+
+		<el-steps :active="activeStep" align-center finish-status="wait">
+			<el-step title="Load backup"></el-step>
+			<el-step title="Information"></el-step>
+			<el-step title="Migration"></el-step>
+			<el-step title="Download backup"></el-step>
+		</el-steps>
+
+		<!-- Upload a backup -->
+		<div v-if="activeStep === 0">
+			
+			<p class="instruction">
+				Provide a Paperback <code>.json</code> Backup
+			</p>
+
+			<!--
+				ref="upload" is used to call clearFiles()
+			-->
+			<el-upload
+				ref="upload"
+				class="upload-backup"
+				drag
+				action="#"
+				:http-request="submitBackup"
+				v-loading="loading"
+			>
+				<i class="el-icon-upload"></i>
+				<div class="el-upload__text">Drop backup here or <em>click to upload</em></div>
+				<div class="el-upload__tip" slot="tip">Upload a Paperback <code>.json</code> backup</div>
+			</el-upload>
+		</div>
+
+		<!-- Backup information -->
+		<div v-if="activeStep === 1">
+			<p class="instruction">
+				Backup successfully imported 
+			</p>
+			<p>
+				The backup countains {{ backupStats.nbManga }} manga and {{ backupStats.nbChapters }} chapters.
+				<br/>
+				{{ backupStats.nbMangaToMigrate }} manga and {{ backupStats.nbChaptersToMigrate }} chapter legacy ids need to be migrated.
+				<br/>
+				Estimated convertion time: {{ Math.round(loadingTotal / 500 *10 ) / 10 }} seconds. <!-- It takes 1 second per request. We convert 500 id by request -->
+			</p>
+			<div class="buttonContainer">
+				<el-button type="danger" plain @click="resetMigrator">Cancel</el-button>
+		  		<el-button type="primary" plain @click="startMigration">Start migration</el-button>
+			</div>
+		</div>
+		<!-- Migration -->
+		<div v-if="activeStep===2">
+			<p class="instruction">
+				Migrating library
+			</p>
+			<p>
+				<!-- loadingDone is increased by 500 on each request and can thus be greater than loadingTotal -->
+				Converted {{ Math.round(loadingDone) > loadingTotal ? loadingTotal : Math.round(loadingDone) }}/{{ loadingTotal }} ids. Please wait...
+			</p>
+			<el-progress :percentage="getLoadingPercentage()" :format="formatLoadingPercentage"></el-progress>
+		</div>
+		<!-- Downloading -->
+		<div v-if="activeStep===3">
+			<p class="instruction">
+				Migrated library
+			</p>
+			<p>
+
+				Successful migration. Converted {{ Math.round(loadingTotal) }} ids.
+				<br />
+				Download your migrated backup.
+				
+			</p>
+			<blockquote v-if="errorsList.length > 0">
+					<p v-for="(error, index) in errorsList" :key="index" :class="error.type">{{ error.message }} </p>
+			</blockquote>
+			<div class="buttonContainer">
+				<el-button type="danger" plain @click="resetMigrator">Cancel</el-button>
+		  		<el-button type="primary" plain @click="downloadData">Download Paperback backup <i class="el-icon-download"></i></el-button>
+			</div>
+		</div>
+
+	</span>
+</template>
+
+<script>
+// Axios is used to make the POST request to the converter
+import axios from "axios";
+
+const REQUESTSSIZE = 500
+
+export default {
+	data() {
+		return {
+			activeStep: 0,
+			loading:false,					// Put the uploader in loading mode
+
+			backupObject: undefined,		// The backup file NOT NEEDED
+			backupJson: undefined,			// Content of the backup, format json
+
+			backupStats: {					// Information about the backup and the process
+				nbManga: 0,
+				nbMangaToMigrate: 0,
+				nbMigratedManga: 0,
+				nbChapters: 0,
+				nbChaptersToMigrate: 0,
+				nbMigratedChapters: 0,
+			},
+
+			mangaAssociationDict: {},				// {mangaLegacyId: {manga:[mangaBackupIndex], chapters:[chapterBackupIndex]}}
+													// backupIndex is the index in the backup lists
+			chaptersAssociationDict: {},			// {chapterLegacyId: {chapters:[chapterBackupIndex]}}
+
+			loadingDone: 0,							// Number of steps already done
+			loadingTotal: 0,						// Number of steps to do
+
+			backupFileName: "",
+			
+			errorsList: [],							// {type: "errorMessage", message: ""}
+			
+		};
+	},
+	
+	methods: {
+
+		// Cancel the current migration and return ti step one
+		resetMigrator() {
+			
+
+			this.$data.activeStep = 0
+			this.$data.loading = false
+			this.$data.backupObject = undefined
+			this.$data.backupJson = undefined
+			this.$data.backupStats= {					// Information about the backup and the process
+				nbManga: 0,
+				nbMangaToMigrate: 0,
+				nbMigratedManga: 0,
+				nbChapters: 0,
+				nbChaptersToMigrate: 0,
+				nbMigratedChapters: 0,
+			}
+			this.$data.mangaAssociationDict = {}
+			this.$data.chaptersAssociationDict = {}
+
+			this.$data.loadingDone = 0
+			this.$data.loadingTotal = 0
+
+			this.$data.backupFileName = ""
+
+			this.errorsList = []
+
+			// We don't need and can't reset the file list for all reset except the invalid file format error
+			//this.$refs.upload.clearFiles();
+		},
+
+		getLoadingPercentage () {
+			if (this.$data.loadingTotal === 0) {
+				// Prevent division by zero
+				return 100
+			}
+			const percentage = Math.round(this.$data.loadingDone / this.$data.loadingTotal * 100)
+			return percentage >= 100 ? 100 : percentage
+		},
+
+		formatLoadingPercentage (percentage) {
+			if (this.$data.loadingTotal === 0) {
+				return "no items"
+			}
+			return `${percentage}%`
+		},
+		
+		// Step 1 process
+		// Called on backup submission
+		submitBackup(data) {
+			// Open the backup, store it and show step 1
+
+			console.log("Backup submitted");
+			this.$data.loading = true
+			this.$data.backupFileName = data.file.name
+
+			if (data.file.type!== 'application/json') {
+				// Invalid file type
+				this.$message({
+					type: 'error',
+					message: 'Invalid file format'
+				});
+				console.error("Migrator: Invalid file format");
+				// We need to reset the migrator and remove the uploaded file from the upload object
+				this.$refs.upload.clearFiles();
+				this.resetMigrator()
+				return
+			}
+			
+			data.file.text().then((value) => {
+
+				const backup = typeof value === "string" ? JSON.parse(value) : value
+				this.$data.backup = backup
+
+				if (backup.backupSchemaVersion !== 1 ) {
+					// We officialy only support backupSchemaVersion 1, if different log an error but try to proceed anyway
+					console.log(`Migrator: unsuported backup schema version version ${backup.backupSchemaVersion}`)
+					this.$data.errorsList.push({type: "errorMessage", message: `INFO: Unsuported backup schema version ${backup.backupSchemaVersion}`})
+				}
+
+				/* Manga legacy ids identification */
+
+				// Manga are saved in backup.sourceMangas
+				// We create a list of (index, legacyId)
+				// We converted, we will just replace the legacyId by the UUID in `backup.sourceMangas` at the index `index`
+				for (const mangaBackupIndex in backup.sourceMangas) {
+					const mangaObject = backup.sourceMangas[mangaBackupIndex]
+					if (mangaObject.sourceId === 'MangaDex') {
+						if (!mangaObject.id.includes('-')) {
+      						// It is a MangaDex manga legacy id, we add it to the association dict
+
+							// We create the object for the id if it does not exist
+							if (this.$data.mangaAssociationDict[mangaObject.id] === undefined) {
+								this.$data.mangaAssociationDict[mangaObject.id] = {manga: [], chapters: []}
+							}
+
+							this.$data.mangaAssociationDict[mangaObject.id].manga.push(mangaBackupIndex)
+						}
+					}
+				}
+				
+
+				/* Chapters legacy ids identification */
+
+				// Chapters are saved in backup.chapterMarkers
+				// We create a list of (index, legacyId)
+				// We converted, we will just replace the legacyId by the UUID in `backup.chapterMarkers` at the index `index`
+				for (const chapterBackupIndex in backup.chapterMarkers) {
+					const chapterObject = backup.chapterMarkers[chapterBackupIndex].chapter
+					if (chapterObject.sourceId === 'MangaDex') {
+						if (!chapterObject.mangaId.includes('-')) {
+							// It is a MangaDex manga legacy id, we add it to the association dict
+
+							// We create the object for the id if it does not exist
+							if (this.$data.mangaAssociationDict[chapterObject.mangaId] === undefined) {
+								this.$data.mangaAssociationDict[chapterObject.mangaId] = {manga: [], chapters: []}
+							}
+
+							this.$data.mangaAssociationDict[chapterObject.mangaId].chapters.push(chapterBackupIndex)
+						}
+						if (!chapterObject.id.includes('-')) {
+      						// It is a MangaDex chapter legacy id, we add it to the association dict
+
+							// We create the object for the id if it does not exist
+							if (this.$data.chaptersAssociationDict[chapterObject.id] === undefined) {
+								this.$data.chaptersAssociationDict[chapterObject.id] = {chapters: []}
+							}
+
+							this.$data.chaptersAssociationDict[chapterObject.id].chapters.push(chapterBackupIndex)
+						}
+					}
+				}
+
+				/* Stats */
+
+				this.$data.backupStats = {
+					nbManga: backup.sourceMangas.length,
+					nbMangaToMigrate: Object.keys(this.$data.mangaAssociationDict).length,
+					nbMigratedManga: 0,
+					nbChapters: backup.chapterMarkers.length,
+					nbChaptersToMigrate: Object.keys(this.$data.chaptersAssociationDict).length,
+					nbMigratedChapters: 0,
+				}
+
+				this.$data.loadingTotal = this.$data.backupStats.nbMangaToMigrate + this.$data.backupStats.nbChaptersToMigrate
+
+				console.log(`Found ${this.$data.loadingTotal} ids to migrate`)
+
+				if (this.$data.backupStats.nbMangaToMigrate === 0) {
+					console.log("No manga ids to convert")
+				}
+				if (this.$data.backupStats.nbChaptersToMigrate === 0) {
+					console.log("No chapters ids to convert")
+				}
+				
+				// Activate the step 1
+				this.$data.activeStep = 1
+			})
+		},
+			
+		
+		async getMangaUUIDs(numericIds, type = 'manga') {
+
+			const requestLength = numericIds.length
+			let offset = 0
+			const UUIDsDict = {}
+
+			while (true) {
+
+				const ids = numericIds.slice(offset, offset + REQUESTSSIZE).map(x => Number(x))
+				const realSize = ids.length
+
+				const data = {
+					'type': type,
+					'ids': ids
+				}
+
+				var request = {
+					"url": "http://localhost:5000/getids",
+					"method": "POST",
+					"timeout": 0,
+					"mimeType": "multipart/form-data",
+					"contentType": 'application/json',
+					"processData": false,
+					"data": data
+				}
+
+				offset += REQUESTSSIZE
+				
+				await axios(request, {crossDomain: true})
+				.then((response) => {
+					console.log(`Successful request: ${type}-${offset}`)
+
+					const json = typeof response.data === "string" ? JSON.parse(response.data) : response.data
+
+					for (const mapping of json) {
+						//console.log(`${mapping.data.attributes.legacyId} -> ${mapping.data.attributes.newId}`)
+						UUIDsDict[mapping.data.attributes.legacyId] = mapping.data.attributes.newId
+					}
+					
+				}, (error) => {
+					console.error(`Migrator: failed request: ${type}-${offset}, error:`)
+					console.log(error)
+					this.$data.errorsList.push({type:"errorMessage", message:`ERROR: Failed request: ${type}-${offset}, see logs`})
+				})		
+				
+				// Wait one second while updating the progress bar
+				const nbLoadingStep = 50
+				const loadingStepDuration = 20
+				const loadingStepSize = (1/nbLoadingStep)*REQUESTSSIZE
+
+				for (let index = 0; index < nbLoadingStep; index++) {
+					await new Promise((resolve) => {
+						setTimeout(resolve, loadingStepDuration);
+						
+					})
+					this.$data.loadingDone += loadingStepSize
+				}
+
+				if (offset >= requestLength) {
+					break
+				}
+
+			}
+			return UUIDsDict
+		},
+
+		// Step 2 process
+		// Called on "Migrate" button click
+		async startMigration(){
+
+			// Show step 2
+			this.$data.activeStep = 2
+
+			console.log("Starting migration")
+			const backup = this.$data.backup
+
+			/* Manga migration */
+			
+			console.log("Migrating manga ids")
+			// We get the mapping legacy / 
+			const mangaUUIDsDict = await this.getMangaUUIDs(Object.keys(this.$data.mangaAssociationDict), 'manga')
+			
+			// We modify ids in the manga backup
+			for (const mangaLegacyId of Object.keys(this.$data.mangaAssociationDict)) {
+				const mangaIndexList = this.$data.mangaAssociationDict[mangaLegacyId].manga
+				const chaptersIndexList = this.$data.mangaAssociationDict[mangaLegacyId].chapters
+
+				if (mangaUUIDsDict[mangaLegacyId] !== undefined) {
+					for (const mangaIndex of mangaIndexList) {
+						backup.sourceMangas[mangaIndex].id = mangaUUIDsDict[mangaLegacyId]
+					}
+					for (const chapterIndex of chaptersIndexList) {
+						backup.chapterMarkers[chapterIndex].chapter.mangaId = mangaUUIDsDict[mangaLegacyId]
+					}
+
+				} else {
+					this.$data.errorsList.push({type: "infoMessage", message: `INFO: Unexisting manga id ${mangaLegacyId}, skipping`})
+					console.log(`Migrator: unexisting manga id ${mangaLegacyId}, skipping`)
+				}
+			}
+			
+
+			
+			/* Chapters migration */
+			
+			console.log("Migrating chapter ids")
+			// We get the mapping legacy / 
+			const chaptersUUIDsDict = await this.getMangaUUIDs(Object.keys(this.$data.chaptersAssociationDict), 'chapter')
+
+			// We modify ids in the backup
+			for (const chapterLegacyId of Object.keys(this.$data.chaptersAssociationDict)) {
+				const chaptersIndexList = this.$data.chaptersAssociationDict[chapterLegacyId].chapters
+
+				if (chaptersUUIDsDict[chapterLegacyId] !== undefined) {
+					for (const chapterIndex of chaptersIndexList) {
+						//console.log("changed index", chapterIndex, " : ", chapterLegacyId, "==>", chaptersUUIDsDict[chapterLegacyId])
+						backup.chapterMarkers[chapterIndex].chapter.id = chaptersUUIDsDict[chapterLegacyId]
+					}
+				} else {
+					this.$data.errorsList.push({type: "infoMessage", message: `INFO: Unexisting chapter id ${chapterLegacyId}, skipping`})
+					console.log(`Migrator: unexisting chapter id ${chapterLegacyId}, skipping`)
+				}
+			}
+
+			/* Inject the new MangaDex source and extensions-promises repository  */
+
+			// Add the new MangaDex source
+			let newActiveSources = []
+
+			for (const i in backup.activeSources) {
+				//console.log(backup.activeSources[i].id)
+				if (backup.activeSources[i].id !== 'MangaDex') {
+					newActiveSources.push(backup.activeSources[i])
+				}
+			}
+
+			newActiveSources.push({
+				"author": "nar1n",
+				"desc": "Extension that pulls manga from MangaDex",
+				"website": "https://github.com/nar1n",
+				"id": "MangaDex",
+				"tags": [{"text":"Recommended","type":"default"},{"text":"Notifications","type":"success"}],
+				"repo": "https://paperback-ios.github.io/extensions-promises",
+				"websiteBaseURL": "https://mangadex.org",
+				"version": "1.0.0",
+				"icon": "icon.png",
+				"name": "MangaDex"
+			})
+
+			backup.activeSources = newActiveSources
+
+			// Search if extensions-promises is in the backup
+			var exist = false
+			for (const i in backup.sourceRepositories) {
+				if (backup.sourceRepositories[i].url === 'https://paperback-ios.github.io/extensions-promises') {
+					exist = true
+				}
+			}
+			// Add the extensions-promises repository if it is not in the backup
+			if (!exist) {
+				backup.sourceRepositories.push({
+					"name": "[PROMISES] Additional Sources",
+					"url": "https://paperback-ios.github.io/extensions-promises"
+				})
+			}
+
+			// We save the new backup in this.$data.backup
+ 			this.$data.backup = backup
+			
+			console.log("Manga Migration finished")
+
+			// We show step 3
+			this.$data.activeStep = 3
+		},
+
+		// Step 3 process
+		downloadData() {
+			/* Tell the browser to start a download operation on a given set of text */
+
+			// The data is in the dictionnary convertedBackupData
+			var element = document.createElement('a')
+
+			element.setAttribute('href', 'data:application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(this.$data.backup)))
+			element.setAttribute('download', 'Md-Migrated-' + this.$data.backupFileName)
+
+			element.style.display = 'none'
+			document.body.appendChild(element)
+			element.click()
+			document.body.removeChild(element)
+			}
+		},
+
+};
+
+</script>
+
+<style lang="stylus">
+.upload-backup
+	text-align center
+.el-upload-dragger
+	background-color #fbfdff
+	border 1.2px dashed #d9d9d9
+	// Prevent the component from being to large
+	width unset
+	padding-left 4rem
+	padding-right 4rem
+.instruction
+	font-size 1.65rem
+	font-weight 600
+	line-height 1.25
+	text-align center
+.buttonContainer
+	text-align center
+	padding-bottom 1rem
+.errorMessage
+	color: $dangerColor
+.infoMessage
+	color $infoColor
+
+</style>

--- a/src/.vuepress/config/nav/en.js
+++ b/src/.vuepress/config/nav/en.js
@@ -29,6 +29,10 @@ module.exports = [
 						text: "Backup Converter",
 						link: "/tools/backup-converter/",
 					},
+					{
+						text: "MangaDex Migrator",
+						link: "/tools/md-to-md-migrator/",
+					},
 				],
 			},
 		],

--- a/src/.vuepress/config/sidebar/en.js
+++ b/src/.vuepress/config/sidebar/en.js
@@ -9,6 +9,6 @@ module.exports = [
 	{
 		title: "Tools",
 		collapsable: false,
-		children: ["/tools/backup-converter"],
+		children: ["/tools/backup-converter", "/tools/md-to-md-migrator"],
 	},
 ];

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -187,6 +187,15 @@ ol
 				color $redAccentColor
 			&__active-bar
 				background-color $redAccentColor
+	.el-steps
+		.el-step__icon.is-text
+			background $darkPrimaryBg
+		// Active step
+		.is-process
+			color $darkTextColor
+			.el-step__icon
+				border-color $darkTextColor
+
 .yuu-theme-purple
 	// Upload component
 	.el-upload-dragger .el-upload__text em

--- a/src/.vuepress/styles/palette.styl
+++ b/src/.vuepress/styles/palette.styl
@@ -25,3 +25,9 @@ $MQMobileNarrow = 419px
 // Fonts
 $buttonFontFamily = 'Open Sans', Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif
 $codeFontFamily = source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace
+
+// Element UI colors
+$successColor = #67C23A
+$warningColor = #E6A23C
+$dangerColor = #F56C6C
+$infoColor = #909399

--- a/src/tools/md-to-md-migrator.md
+++ b/src/tools/md-to-md-migrator.md
@@ -6,14 +6,14 @@ lang: en-US
 :::: guide MangaDex to MangaDex backup migrator
 MangaDex changed their ids to UUIDS. If the source remains compatible with legacy ids, using them will be slower as it requires to call a conversion endpoint every time.
 
-To migrate you library:
+To migrate your library:
 1. [Make a backup](/help/faq/#how-can-i-make-a-backup-of-my-library) of your library
 1. Convert your backup with this *MangaDex to MangaDex backup migrator*
 1. Reinstall Paperback
 1. [Restore](/help/faq/#how-can-i-make-a-backup-of-my-library) the migrated backup
 
 ::: aside
-Please note the conversion can take some time on big libraries
+Please note that the conversion can take some time on big libraries
 :::
 ::::
 

--- a/src/tools/md-to-md-migrator.md
+++ b/src/tools/md-to-md-migrator.md
@@ -1,0 +1,30 @@
+---
+title: MangaDex backup migrator
+lang: en-US
+---
+
+:::: guide MangaDex to MangaDex backup migrator
+MangaDex changed their ids to UUIDS. If the source remains compatible with legacy ids, using them will be slower as it requires to call a conversion endpoint every time.
+
+To migrate you library:
+1. [Make a backup]() of your library
+1. Convert your backup with this *MangaDex to MangaDex backup migrator*
+1. Reinstall Paperback
+1. [Restore]() the migrated backup
+
+::: aside
+Please note the conversion can take some time on big libraries
+:::
+::::
+
+<br/>
+<br/>
+
+<MdToMdMigrator/>
+
+<style>
+.custom-block.aside
+{
+    text-align: left;
+}
+</style>

--- a/src/tools/md-to-md-migrator.md
+++ b/src/tools/md-to-md-migrator.md
@@ -7,10 +7,10 @@ lang: en-US
 MangaDex changed their ids to UUIDS. If the source remains compatible with legacy ids, using them will be slower as it requires to call a conversion endpoint every time.
 
 To migrate you library:
-1. [Make a backup]() of your library
+1. [Make a backup](/help/faq/#how-can-i-make-a-backup-of-my-library) of your library
 1. Convert your backup with this *MangaDex to MangaDex backup migrator*
 1. Reinstall Paperback
-1. [Restore]() the migrated backup
+1. [Restore](/help/faq/#how-can-i-make-a-backup-of-my-library) the migrated backup
 
 ::: aside
 Please note the conversion can take some time on big libraries


### PR DESCRIPTION
Add a migrator replacing MangaDex legacy ids by their corresponding UUIDs.

<img width="938" alt="Capture d’écran 2021-05-23 à 09 07 49" src="https://user-images.githubusercontent.com/25133304/119251366-795c7600-bba6-11eb-8602-e166516d21a7.png">
