### PR TITLE
New Installation guide

### DIFF
--- a/src/.vuepress/components/PaperbackHome.vue
+++ b/src/.vuepress/components/PaperbackHome.vue
@@ -51,18 +51,6 @@ Custom home page based on Vuepress default theme home page
             class="lightrendered"
           >   
         </a>-->
-        <a href="https://testflight.apple.com/join/pRG9XsHu"> 
-          <img
-            :src="'/assets/AppStore/AppStore_' + data.lang + '_White.svg'"
-            alt="Download on the App Store"
-            class="darkrendered"
-          > 
-          <img
-            :src="'/assets/AppStore/AppStore_' + data.lang + '_Black.svg'"
-            :alt="data.buttonDownload"
-            class="lightrendered"
-          >   
-        </a>
        
         <!-- User guide button -->
         <!-- RouterLink is used by the NavLink component --> 

--- a/src/.vuepress/config/sidebar/en.js
+++ b/src/.vuepress/config/sidebar/en.js
@@ -7,6 +7,15 @@ module.exports = [
 		children: ["/help/guides/getting-started", "/help/guides/adding-repos"],
 	},
 	{
+		title: "Installation",
+		collapsable: true,
+		children: [
+			"/help/installation/public-testflight",
+			"/help/installation/public-altstore",
+			"/help/installation/beta-testflight"
+		]
+	},
+	{
 		title: "Tools",
 		collapsable: true,
 		children: ["/tools/backup-converter"],

--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -5,38 +5,25 @@ lang: en-US
 
 # Getting started
 
-## Installation
-Currently an early version of the app is available on TestFlight!
-
-If you are a patron, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The Patreon version of the application contains many additional beta features which can be used before it becomes available on the public one.
-
 ::: warning Warning
 This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the app will CRASH. Paperback is NOT designed for older iOS and iPadOS versions.
 :::
 
-:::: el-tabs
-::: el-tab-pane label="Public version"
-### TestFlight
-#### Instructions
-1. Remove every other version of Paperback
-1. Download the [TestFlight app](https://apps.apple.com/fr/app/testflight/id899247664) from App Store
-1. Accept the invite by going here [https://testflight.apple.com/join/pRG9XsHu](https://testflight.apple.com/join/pRG9XsHu) or redeem the code `pRG9XsHu`
-1. Download the application through TestFlight
-   > Whenever there is an update to the application, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
-:::
+## Installation
+Currently an early version of the app is available on TestFlight or can be sideloaded with AltStore!
 
-::: el-tab-pane label="Patreon version"
-### TestFlight
-#### Instructions
-1. After registering as a [Patreon](https://www.patreon.com/FaizanDurrani) to Paperback, you should receive an email from TestFlight with an invitation to the beta version of Paperback
-   > You may not get your invitation immediately, sometimes it takes a few hours for your registration to be sent to TestFlight. If you have waited over a day, contact us on Discord
-1. Inside of the email, click the button labeled "View in TestFlight"
-1. Download the TestFlight app onto your device from the App Store
-1. At the top of your TestFlight app, there is a "Redeem" button. Select this, and input the code which you have received through the email link
-1. Download the application through TestFlight
-   > Whenever there is an update to the beta, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
-:::
-::::
+ * Check our [TestFlight installation guide](/help/installation/public-testflight/)
+ * Check our [AltStore installation guide](/help/installation/public-altstore/)
+
+If you are a patron, you will receive an email to your patreon address regarding information about accessing Paperback through TestFlight. The Patreon version of the application contains many additional beta features which can be used before it becomes available on the public one.
+
+ * Check our [Patron installation guide](/help/installation/beta-testflight/)
+
+---
+
+## Installation FAQ
+### I'm not a patron, should I use TestFlight or AltStore?
+If the TestFlight is not at capacity, [TestFlight installation](/help/installation/beta-testflight/) would be recommend as it is easier to use.
 
 ---
 

--- a/src/help/installation/beta-testflight.md
+++ b/src/help/installation/beta-testflight.md
@@ -1,0 +1,26 @@
+---
+title: Install the patron version
+lang: en-US
+---
+
+# Install the patron version
+
+> If you are not a patron and want to install the public build, you can check our other [installation guide](/help/guide/getting-started).
+
+::: warning Warning
+This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the app will CRASH. Paperback is NOT designed for older iOS and iPadOS versions.
+:::
+
+## Installation
+1. After registering as a [Patreon](https://www.patreon.com/FaizanDurrani) to Paperback, you should receive an email from TestFlight with an invitation to the beta version of Paperback
+   > You may not get your invitation immediately, sometimes it takes a few hours for your registration to be sent to TestFlight. If you have waited over a day, contact us on Discord
+1. Inside of the email, click the button labeled "**View in TestFlight**"
+1. Download the TestFlight app onto your device from the App Store
+1. At the top of your TestFlight app, there is a "**Redeem**" button. Select this, and input the code which you have received through the email link
+1. Download the application through TestFlight
+   > Whenever there is an update to the beta, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
+
+---
+
+## App Troubleshooting
+If you're having problems with the app, please check the **[Troubleshooting page](/help/faq/#troubleshooting)**. If you're having an issue that is not mentioned on the troubleshooting page, please use the #support channel on **[Discord](https://discord.gg/Ny83JV3)** to ask questions.

--- a/src/help/installation/public-altstore.md
+++ b/src/help/installation/public-altstore.md
@@ -9,7 +9,7 @@ lang: en-US
 **Paperback** can be sideloaded with **AltStore**.
 
 :::: tip Video tutorial
-If you prefer using a video tutorial, Artesians made a beautiful one. You will find it [here](https://www.youtube.com/watch?v=n1KRwsxNiWY) for Windows and [here](https://www.youtube.com/watch?v=CjPjsF4yJ0M) for macOS.
+If you prefer using a video tutorial, Artesians made a beautiful one. You will find it [here](https://www.youtube.com/watch?v=2NBACQHgF-I) for Windows and [here](https://www.youtube.com/watch?v=qTgiHQVgulg) for macOS.
 
 :::aside
 The installation guides use outdated UI. Please ignore it.

--- a/src/help/installation/public-altstore.md
+++ b/src/help/installation/public-altstore.md
@@ -53,7 +53,7 @@ This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the a
 1. Trust AltStore application: On your device, go to Settings > General > Device Management. Choose your Apple ID and select **Trust**.
 1. Launch **AltStore** on your iPhone/iPad.
 1. Go to **My Apps** and tap the **+** icon in the top left corner.
-1. Open the **`.IPA`** you downloaded from the [Prerequisites](/help/guides/getting-started/#prerequisites) section.
+1. Open the **`.IPA`** you downloaded from the [Prerequisites](#prerequisites) section.
 1. **Paperback** should finally be installed!
 :::
 
@@ -83,7 +83,7 @@ This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the a
 1. Trust AltStore application: On your device, go to Settings > General > Device Management. Choose your Apple ID and select **Trust**.
 1. Launch **AltStore** on your iPhone/iPad.
 1. Go to **My Apps** and tap the **+** icon in the top left corner.
-1. Open the **`.IPA`** you downloaded from the [Prerequisites](/help/guides/getting-started/#prerequisites) section.
+1. Open the **`.IPA`** you downloaded from the [Prerequisites](#prerequisites) section.
 1. **Paperback** should finally be installed!
 :::
 ::::

--- a/src/help/installation/public-altstore.md
+++ b/src/help/installation/public-altstore.md
@@ -1,0 +1,104 @@
+---
+title: Install with AltStore
+lang: en-US
+---
+
+# Install the public build with AltStore
+
+## Installation
+**Paperback** can be sideloaded with **AltStore**.
+
+:::: tip Video tutorial
+If you prefer using a video tutorial, Artesians made a beautiful one. You will find it [here](https://www.youtube.com/watch?v=n1KRwsxNiWY) for Windows and [here](https://www.youtube.com/watch?v=CjPjsF4yJ0M) for macOS.
+
+:::aside
+The installation guides use outdated UI. Please ignore it.
+:::
+
+::::
+
+### Prerequisites
+1. On your iPhone or iPad, download the app <Download text="from here"/>. The app will download as **`Paperback.ipa`**.
+1. Download [AltServer](https://altstore.io/) for your operating system.
+
+::: warning Warning
+This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the app will CRASH. Paperback is NOT designed for older iOS versions.
+:::
+
+:::: el-tabs
+::: el-tab-pane label="macOS 10.14+"
+### AltStore
+#### Instructions
+1. Move "**AltServer.app**" to your *Applications* folder and launch it (it will appear as an icon in the menu bar).
+1. Connect your **iPhone** or **iPad** to your computer and make sure it's unlocked and your device is trusted.
+1. **Mojave** users need to open **iTunes** and enable "**iTunes Wi-Fi sync**" for your iPhone/iPad.
+   **Catalina** users need to open **Finder** and enable "**Show this iPhone when on WiFi**" for your iPhone/iPad.
+1. Click the **AltServer** icon in the Mac menu bar and click "**Install AltStore**" and select your iPhone/iPad.
+1. Enter your Apple ID email and password. (**BOTH** are case sensitive)
+   > *Your Apple ID and password are sent to Apple, and nowhere else.*
+1. **AltServer** will ask you to install a Mail plug-in, follow the instructions to continue. This is only required the first time.
+1. Wait a few seconds, then AltStore will be installed to your iPhone/iPad.
+
+#### Mail plug-in
+1. Click the "**Install Mail Plug-in**" from the AltServer menu.
+1. Enter your password to grant AltServer permission to install the plug-in.
+1. Restart the Mail app and open Preferences `(CMD+,)`.
+1. Click "**Manage Plug-ins**" and enable "**AltPlugin.mailbundle**".
+1. Finally, click "**Apply and Restart Mail**" to finish the installation.
+
+### Paperback
+#### Installation
+1. Open **Mail** and **AltServer**.
+1. Make sure you're on the *same connection* (same router, in most cases) as the computer running **AltServer**. If you're not connected to the same network, you can connect your device via cable.
+1. Trust AltStore application: On your device, go to Settings > General > Device Management. Choose your Apple ID and select **Trust**.
+1. Launch **AltStore** on your iPhone/iPad.
+1. Go to **My Apps** and tap the **+** icon in the top left corner.
+1. Open the **`.IPA`** you downloaded from the [Prerequisites](/help/guides/getting-started/#prerequisites) section.
+1. **Paperback** should finally be installed!
+:::
+
+::: el-tab-pane label="Windows 10"
+### AltStore
+#### Instructions
+1. Download and install the latest version of [iTunes](https://www.apple.com/itunes/) for Windows.
+   <el-tag type="warning">Not the Microsoft Store app!</el-tag>
+1. Download and install the latest version of [iCloud](https://support.apple.com/en-us/HT204283).
+   <el-tag type="warning">Not the Microsoft Store app!</el-tag>
+1. Restart your PC after you've installed both **iTunes** and **iCloud**.
+   <el-tag type="warning">You need to restart your computer!</el-tag>
+1. Extract the downloaded **`AltInstaller.zip`** file. Run **`setup.exe`** and follow the instructions.
+1. Launch **AltServer** from your *Notification Area*.
+   > Can't find **AltServer**? <PictureDialog title="Launch AltServer" button="Image" src="/assets/AltServer.png"/>
+1. Connect your **iPhone** or **iPad** to your computer and make sure it's unlocked and your device is trusted.
+1. Open **iTunes** and enable "**iTunes Wi-Fi sync**" for your iPhone/iPad.
+1. Click the **AltServer** icon in your *Notification Area* and click "**Install AltStore**", then select your iPhone/iPad.
+1. Enter your Apple ID email and password. (**BOTH** are case sensitive)
+   > *Your Apple ID and password are sent to Apple, and nowhere else.*
+1. AltStore should be installed to your iPhone/iPad.
+
+### Paperback
+#### Installation
+1. Open **AltServer** along with **iCloud** and **iTunes**.
+1. Make sure you're on the *same connection* (same router, in most cases) as the computer running **AltServer**. If you're not connected to the same network, you can connect your device via cable.
+1. Trust AltStore application: On your device, go to Settings > General > Device Management. Choose your Apple ID and select **Trust**.
+1. Launch **AltStore** on your iPhone/iPad.
+1. Go to **My Apps** and tap the **+** icon in the top left corner.
+1. Open the **`.IPA`** you downloaded from the [Prerequisites](/help/guides/getting-started/#prerequisites) section.
+1. **Paperback** should finally be installed!
+:::
+::::
+
+## Installation FAQ
+### I get "Access Denied" when trying to install AltStore
+Run AltServer as an administrator and ensure that you've restarted your computer after installing iTunes and iCloud.
+
+### I can't find the .IPA file to download
+You can download the **`.IPA`** file <Download text="from here"/>.
+
+### I have some other issue that isn't listed here
+Check the [AltStore FAQ](https://altstore.io/faq/). If you still can't resolve the issue visit the #support-ipa channel on our **[Discord](https://discord.gg/Ny83JV3)** for a fast response or submit a post on **[Reddit](https://www.reddit.com/r/Paperback/)**.
+
+---
+
+## App Troubleshooting
+If you're having problems with the app, please check the **[Troubleshooting page](/help/faq/#troubleshooting)**. If you're having an issue that is not mentioned on the troubleshooting page, please use the #support channel on **[Discord](https://discord.gg/Ny83JV3)** to ask questions.

--- a/src/help/installation/public-testflight.md
+++ b/src/help/installation/public-testflight.md
@@ -1,0 +1,30 @@
+---
+title: Install with TestFlight
+lang: en-US
+---
+
+# Install the public build with TestFlight
+
+::: warning Warning
+This app requires iOS 13.4+ or iPadOS 13.4+. If you have an older version, the app will CRASH. Paperback is NOT designed for older iOS and iPadOS versions.
+:::
+
+### TestFlight
+#### Instructions
+1. Remove every other version of Paperback
+1. Download the [TestFlight app](https://apps.apple.com/fr/app/testflight/id899247664) from App Store
+1. Accept the invite by going here [https://testflight.apple.com/join/pRG9XsHu](https://testflight.apple.com/join/pRG9XsHu) or redeem the code `pRG9XsHu`
+1. Download the application through TestFlight
+   > Whenever there is an update to the application, you will have to return to TestFlight and select the "Update" button next to the app. It does not do this process automatically. If the setting is enabled for TestFlight, you will get a push notification to your device whenever an update is available
+
+---
+
+## Installation FAQ
+### I get "The beta is full" when trying to install the app
+There can only be a limited number of testers on TestFlight due to the 10k testers limit enforced by Apple.
+To install the app you can use an other method of installation like [AltStore sideloading](/help/installation/public-altstore/).
+
+---
+
+## App Troubleshooting
+If you're having problems with the app, please check the **[Troubleshooting page](/help/faq/#troubleshooting)**. If you're having an issue that is not mentioned on the troubleshooting page, please use the #support channel on **[Discord](https://discord.gg/Ny83JV3)** to ask questions.


### PR DESCRIPTION
 - Remove the "download from the App Store": as there are multiple installation method, not having a button on the homepage would be less confusing
 - Create a dedicated page for each installation method
 - Update the "getting-started" page to present installation methods