### PR TITLE
docs: fix stale contributing TODO and improve guide copy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ For major changes, please open an issue first to discuss what you would like to 
 
 You will need [Node.js](http://nodejs.org) **version 18+**.
 
-After cloning the repo and entering the the directory, run:
+After cloning the repo and entering the directory, run:
 
 ```bash
 # Installs any dependencies needed.
@@ -39,24 +39,24 @@ $ npm install
 To run a development server for the website now, run:
 
 ```bash
-# This command start a local server you can access and edit live.
-$ npm dev
+# This command starts a local server you can access and edit live.
+$ npm run dev
 ```
 
 To test and build the website, run:
 
 ```bash
-# This command tests and builds the website
-$ npm build
+# This command tests and builds the website.
+$ npm run build
 ```
 
 > Fix any issues that pop up and then run this command again.
 
-To preview the previously build website, run
+To preview the previously built website, run:
 
 ```bash
-# This command starts a local server you can access and use view the build.
-$ npm preview
+# This command starts a local server you can use to view the build.
+$ npm run preview
 ```
 
 **Note:** There are git hooks in place to run the build tests on commits as well. Pull requests with failing tests will not be merged.
@@ -82,11 +82,10 @@ $ npm preview
 
 A list of to do items for the website:
 
-- Update to version +9.0 of ESLint and switch to a flat config.
-- Update and add the following contributing guides:
-  - Extension Contributing
-  - Website Contributing
-- Add the following tools to the website:
+- Expand and improve the following contributing guides:
+  - Extension Development
+  - Website Contribution
+- Finish and ship the following tools:
   - Backup Converter
   - Themes Creator
 

--- a/.github/SUPPORT_DISCLAIMER.md
+++ b/.github/SUPPORT_DISCLAIMER.md
@@ -14,7 +14,7 @@ Refer to the [Table of Contents](#table-of-contents) to explore the various type
   - [Submitting a Good Bug Report](#submitting-a-good-bug-report)
 - [Suggesting Enhancements](#suggesting-enhancements)
   - [Before Submitting an Enhancement suggestion](#before-submitting-an-enhancement-suggestion)
-  - [Submiting a Good Enhancement Suggestion](#submiting-a-good-enhancement-suggestion)
+  - [Submitting a Good Enhancement Suggestion](#submitting-a-good-enhancement-suggestion)
 
 ## I Have a Question
 
@@ -68,7 +68,7 @@ This section guides you through submitting an enhancement suggestion for the web
 - Perform a [search](https://github.com/Paperback-iOS/website/issues?q=label%3Aenhancement) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this enhancement. Keep in mind that we want enhancements that will be useful to the majority of our users and not just a small subset.
 
-### Submiting a Good Enhancement Suggestion
+### Submitting a Good Enhancement Suggestion
 
 Enhancement suggestions are tracked as [GitHub issues](https://github.com/Paperback-iOS/website/issues).
 

--- a/src/contributing/extension-development/reference/model-reference.md
+++ b/src/contributing/extension-development/reference/model-reference.md
@@ -52,7 +52,7 @@ number.
 | `name`   | String                                                                                               | The title of the chapter.                                                                                                                                                                            |
 | `volume` | Number                                                                                               | The volume that the chapter belongs to. It is recommended to leave the volume number out if every chapter does not have a corresponding volume number, as the volume number interferes with sorting. |
 | `group`  | String                                                                                               | The group that posted the chapter.                                                                                                                                                                   |
-| `time`   | [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object | The date that the chapter is published. If omitted, the chapter will have a creation of the time when the chapter list was loaded.                                                                   |
+| `time`   | [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object | The date that the chapter was published. If omitted, the chapter will use the time when the chapter list was loaded.                                                                                 |
 
 ## ChapterDetails
 

--- a/src/contributing/index.md
+++ b/src/contributing/index.md
@@ -16,7 +16,7 @@ The official Paperback extension is used for connecting the Paperback app with y
 
 ### Paperback website
 
-Any assistance in improving this website is greatly appreciated. Begin with our [website development guide](/contributing/extension-development/).
+Any assistance in improving this website is greatly appreciated. Begin with our [website development guide](/contributing/website/).
 
 ### Paperback Toolchain and Types
 

--- a/src/guides/themes.md
+++ b/src/guides/themes.md
@@ -9,7 +9,7 @@ import ThemesListParser from '../.vitepress/components/ThemesListParser.vue'
 
 # Changing the Theme
 
-Bellow you can find a list of all publicly available themes. You can find info regarding making your own theme at the bottom of the page as well.
+Below you can find a list of all publicly available themes. You can find information about making your own theme at the bottom of the page as well.
 
 ## Available Themes
 
@@ -21,7 +21,7 @@ Bellow you can find a list of all publicly available themes. You can find info r
 
 [Go to Tools](/tools/) -->
 
-For more info on making themes you can check the follow GitHub repositories:
+For more information on making themes, you can check the following GitHub repositories:
 
 1. [Paperback Themes:](https://github.com/Celarye/Paperback-themes) Offers an advanced command-line interface program for editing and creating themes.
 2. [Paperback Themes GUI:](https://github.com/LucifersCircle/paperback-themes-gui) A user-friendly graphical interface for editing and creating themes.

--- a/src/guides/trackers.md
+++ b/src/guides/trackers.md
@@ -1,6 +1,6 @@
 ---
 title: Connecting Trackers
-description: Enable automatic tracking for alternative backups and monitoring your reading progress.
+description: Enable automatic tracking and monitor your reading progress.
 ---
 
 # Connecting Trackers
@@ -11,7 +11,7 @@ Adding external trackers is an optional but recommended step, this will prevent 
 - [**MyAnimeList:**](https://myanimelist.net) The tracker with the biggest userbase.
 - [**MangaUpdates:**](https://mangaupdates.com) An alternative smaller tracker.
 
-We recommend that you use AniList, this because it has as modern user interface and one of if not the largest manga libraries. Trackers are installed the same way as content providing extensions. Bellow follows a guide on how to install and setup the AniList extension, the process for installing other tracker extensions is similar (they are located in the same repository).
+We recommend that you use AniList because it has a modern user interface and one of the largest manga libraries. Trackers are installed the same way as content-providing extensions. Below is a guide on how to install and set up the AniList extension. The process for installing other tracker extensions is similar, as they are located in the same repository.
 
 ## 1. Adding the Tracker Repository
 


### PR DESCRIPTION
## Summary

This PR makes a few small documentation fixes across the Paperback website repo.

Changes included:
- updated the stale TODO list in `.github/CONTRIBUTING.md` to reflect the repo's current state
- fixed contributor setup commands to use `npm run dev`, `npm run build`, and `npm run preview`
- corrected the website contribution guide link in `src/contributing/index.md`
- cleaned up a few wording and typo issues in public-facing docs

## Why

Some of the contribution docs were outdated or misleading:
- the TODO list still referenced work that appears to already be completed
- the setup commands in the contributing guide did not match the scripts in `package.json`
- one contributing link pointed to the wrong section

These are small changes, but they make the docs more accurate for new contributors.